### PR TITLE
fix request access token method

### DIFF
--- a/src/API/Api.php
+++ b/src/API/Api.php
@@ -148,7 +148,7 @@ class Api
     {
         $params['grant_type'] = $grantType;
 
-        $response = $this->client->request('GET', $this->config['endpoints']['oauth'] . $method, [
+        $response = $this->client->request('POST', $this->config['endpoints']['oauth'] . $method, [
             'headers' => [
                 'Authorization' => 'Basic ' . base64_encode($this->config['api']['key'] . ':' . $this->config['api']['secret']),
             ],


### PR DESCRIPTION
I had an error about '403 Forbidden' when i was trying to retrieve the access token with grant type 'password'.

In the docs the method should be 'POST' and not 'GET' -> https://documentation-apidocumentation.trustpilot.com/authentication 

After this fix everything is working properly like usual, can you check this?

Thanks